### PR TITLE
Async

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,4 +12,4 @@ License: lgpl-3.0
 Imports: httr, jsonlite, stringr, rlang, dplyr, data.table
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 6.1.0
+RoxygenNote: 6.1.1

--- a/R/query.R
+++ b/R/query.R
@@ -51,7 +51,7 @@ do_query <- function(query, server.url = NULL, timeout = NULL, print.json = FALS
     if(print.json)
         message(query.json)
 
-    response <- httr::RETRY("POST", url = server.url, body = query.json, encode = "raw")
+    response <- httr::RETRY("POST", url = server.url, body = query.json, encode = "raw", async = TRUE)
 
     response.content <- httr::content(response, simplifyVector = TRUE)
 

--- a/man/do_query.Rd
+++ b/man/do_query.Rd
@@ -4,8 +4,8 @@
 \alias{do_query}
 \title{Runs a query agains the database}
 \usage{
-do_query(query, server.url = NULL, timeout = NULL,
-  print.json = FALSE, ...)
+do_query(query, server.url = NULL, query.timeout = NULL,
+  datalogr.timeout = NULL, print.json = FALSE, ...)
 }
 \arguments{
 \item{query}{The query as returned by \code{\link{query}}}
@@ -13,7 +13,9 @@ do_query(query, server.url = NULL, timeout = NULL,
 \item{server.url}{Optional. The server URL against which the
 query is run. This can be set globally using \code{\link{set_server_url}}}
 
-\item{timeout}{Optional. The query timeout in milliseconds}
+\item{query.timeout}{Optional. The query timeout in milliseconds}
+
+\item{datalogr.timeout}{Optional. Time for datalogr to wait for query to finish in milliseconds}
 
 \item{print.json}{If set to \code{TRUE}, prints the JSON version of the query
 that is sent to the server (useful for debugging purposes)}


### PR DESCRIPTION
Changes to datalogr do_query to allow for waiting for a query to finish before returning the results. Adds async = TRUE when query.timeout is specified.

timeout changed to query.timeout, and datalogr.timeout is added to specify the amount of time datalogr should spend retrying waiting for the s3 link containing results to be updated.