### PR TITLE
fix empty error messages on invalid queries

### DIFF
--- a/R/query.R
+++ b/R/query.R
@@ -75,7 +75,12 @@ do_query <- function(query, server.url = NULL, timeout = NULL, print.json = FALS
                 if(httr::status_code(x) == 200) {
                     x <- httr::content(x, simplifyVector = TRUE)
                     if(x$status %in% c("fail-query", "fail-malformed-query", "fail-error", "fail-memory")) {
-                        stop(sprintf("Query failed with status:%s\nerror message:%s", query$status, x$"error-message"))
+                        if ("error-message" %in% colnames(x)) {
+                            candel.error <- x$`error-message`
+                        } else {
+                            candel.error <- "Server error message was empty!"
+                        }
+                        stop(sprintf("Query failed with status: %s\nerror message: %s", x$status, candel.error))
                     }
                     else if(x$status %in% c("success", "success-cached")) {
                         res.data <- httr::RETRY("GET", url = x$"results-url", times = 1000, quiet = T)

--- a/R/query.R
+++ b/R/query.R
@@ -57,7 +57,12 @@ do_query <- function(query, server.url = NULL, timeout = NULL, print.json = FALS
         message(query.json)
 
     headers <- httr::add_headers(Authorization = paste("Token", auth.token))
-    response <- httr::RETRY("POST", url = server.url, body = query.json, encode = "raw", config = headers)
+    response <- httr::RETRY("POST",
+                            url = server.url,
+                            body = query.json,
+                            encode = "raw",
+                            config = headers,
+                            pause_base = 1)
 
     response.content <- httr::content(response, simplifyVector = TRUE)
 
@@ -75,8 +80,8 @@ do_query <- function(query, server.url = NULL, timeout = NULL, print.json = FALS
                 if(httr::status_code(x) == 200) {
                     x <- httr::content(x, simplifyVector = TRUE)
                     if(x$status %in% c("fail-query", "fail-malformed-query", "fail-error", "fail-memory")) {
-                        if ("error-message" %in% colnames(x)) {
-                            candel.error <- x$`error-message`
+                        if ("error-message" %in% names(x)) {
+                            candel.error <- x$"error-message"
                         } else {
                             candel.error <- "Server error message was empty!"
                         }


### PR DESCRIPTION
This fixes R's falling over on error handling (sprintf threw b/c var it's column referencing status from as well as attempting to get non-existent column). The server side failure (not reporting the cause of the error in the query status response) still needs to be addressed elsewhere.

Previously, error was:

```Error in datalogr::do_query(query = query, server.url = server.url, auth.token = pkg.env$auth.token,  : ```

Now, error is:

```
 Error in datalogr::do_query(query = query, server.url = server.url, auth.token = pkg.env$auth.token,  : 
  Query failed with status: fail-query
error message: Server error message was empty! 
```