### PR TITLE
Add skip.cache keyword arg to do_query

### DIFF
--- a/R/query.R
+++ b/R/query.R
@@ -36,7 +36,7 @@ ensure_server_url <- function(server.url) {
 #'   case the column names are taken from the symbols that appear in the \code{find}
 #'   portion of the query
 #' @export
-do_query <- function(query, server.url = NULL, timeout = NULL, print.json = FALSE, auth.token = NULL, verbose = FALSE, optimize = TRUE, ...) {
+do_query <- function(query, server.url = NULL, timeout = NULL, print.json = FALSE, auth.token = NULL, verbose = FALSE, optimize = TRUE, skip.cache = FALSE, ...) {
     server.url <- ensure_server_url(server.url)
     qq <- query
     if(is.null(qq$query$"in"))
@@ -46,6 +46,7 @@ do_query <- function(query, server.url = NULL, timeout = NULL, print.json = FALS
     qq$timeout <- timeout
     qq$async <- TRUE # To support old API, remove eventually
     qq$optimize <- optimize
+    qq$"skip-cache" <- skip.cache
 
     pull.query <- is_pull_query(query)
 

--- a/R/query.R
+++ b/R/query.R
@@ -75,7 +75,12 @@ do_query <- function(query, server.url = NULL, timeout = NULL, print.json = FALS
                 if(httr::status_code(x) == 200) {
                     x <- httr::content(x, simplifyVector = TRUE)
                     if(x$status %in% c("fail-query", "fail-malformed-query", "fail-error", "fail-memory")) {
-                        stop(sprintf("Query failed with status:%s\nerror message:%s", query$status, x$"error-message"))
+                        if ("error-message" %in% colnames(x)) {
+                            candel.error <- x$`error-message`
+                        } else {
+                            candel.error <- "Server error message was empty!"
+                        }
+                        stop(sprintf("Query failed with status: %s\nerror message: %s", x$status, candel.error))
                     }
                     else if(x$status %in% c("success", "success-cached")) {
                         res.data <- httr::RETRY("GET", url = x$"results-url", times = 1000, quiet = T)

--- a/R/query.R
+++ b/R/query.R
@@ -57,7 +57,12 @@ do_query <- function(query, server.url = NULL, timeout = NULL, print.json = FALS
         message(query.json)
 
     headers <- httr::add_headers(Authorization = paste("Token", auth.token))
-    response <- httr::RETRY("POST", url = server.url, body = query.json, encode = "raw", config = headers)
+    response <- httr::RETRY("POST",
+                            url = server.url,
+                            body = query.json,
+                            encode = "raw",
+                            config = headers,
+                            pause_base = 1)
 
     response.content <- httr::content(response, simplifyVector = TRUE)
 
@@ -75,8 +80,8 @@ do_query <- function(query, server.url = NULL, timeout = NULL, print.json = FALS
                 if(httr::status_code(x) == 200) {
                     x <- httr::content(x, simplifyVector = TRUE)
                     if(x$status %in% c("fail-query", "fail-malformed-query", "fail-error", "fail-memory")) {
-                        if ("error-message" %in% colnames(x)) {
-                            candel.error <- x$`error-message`
+                        if ("error-message" %in% names(x)) {
+                            candel.error <- x$"error-message"
                         } else {
                             candel.error <- "Server error message was empty!"
                         }


### PR DESCRIPTION
This adds a skip.cache keyword to do_query which, when supplied, indicates that the server should execute query and return new results instead of hitting cached results.

NOTE: due to a git error this was branched off of #9 -- can rebase if need be (if that won't be merge order).